### PR TITLE
fix vgmstream-cli invocation for POSIX

### DIFF
--- a/src/Edelstein.Tools.AssetsDownloader/MediaDecryptor.cs
+++ b/src/Edelstein.Tools.AssetsDownloader/MediaDecryptor.cs
@@ -158,7 +158,7 @@ public class MediaDecryptor
         ProcessStartInfo psi = new()
         {
             FileName = "vgmstream-cli",
-            Arguments = $"\"{inputFilePath}\" -o \"{Path.Combine(outputDir, "?n.wav")}\" -S 0",
+            Arguments = $"-o \"{Path.Combine(outputDir, "?n.wav")}\" -S 0 \"{inputFilePath}\"",
             UseShellExecute = false,
             RedirectStandardOutput = true,
             RedirectStandardError = true,


### PR DESCRIPTION
On Linux and macOS, vgmstream-cli uses the POSIX `getopt` function, which enforces a specific options standard; one where it parses options before non-options. However, it is my understanding that on Windows, vgmstream-cli uses the glibc `getopt` function, which is different in that it is flexible in what positions it can parse options passed to the program in.

Because of this, the tool fails on POSIX systems when waiting for vgmstream-cli to exit cleanly. vgmstream-cli throws the error `input files must go after options`. Simply swapping the arguments around completely takes care of the discrepancy, as it appeases the syntax of both `getopt` types.

I tested this PR on both Windows (x64) and macOS (arm64) and there are no issues with decryption on either of them.